### PR TITLE
Add support for Custom Events

### DIFF
--- a/InstanaExample/App.js
+++ b/InstanaExample/App.js
@@ -72,6 +72,21 @@ export default class App extends Component {
     request.send();
   }
 
+  async onSendCustomEvent() {
+    var date = new Date();
+    var epochMs = date.getTime();
+    Instana.reportEvent("myCustomEvent", {
+      start_time: epochMs-500,
+      duration: 300,
+      view_name: "overridenViewName",
+      backend_tracing_id: "1234567890",
+      meta: {
+        key_one: "value_one",
+        key_two: "value_two",
+      },
+    });
+  }
+
   render() {
     return (
       <SafeAreaView style={styles.container}>
@@ -85,6 +100,12 @@ export default class App extends Component {
         <Button
           onPress={this.onRunXMLHttpRequest}
           title="Run `XMLHttpRequest`"
+        />
+        </View>
+        <View  style={{marginTop:10}}>
+        <Button
+          onPress={this.onSendCustomEvent}
+          title="Send `CustomEvent`"
         />
         </View>
       </SafeAreaView>

--- a/InstanaExample/App.js
+++ b/InstanaExample/App.js
@@ -76,13 +76,13 @@ export default class App extends Component {
     var date = new Date();
     var epochMs = date.getTime();
     Instana.reportEvent("myCustomEvent", {
-      start_time: epochMs-500,
+      startTime: epochMs-500,
       duration: 300,
-      view_name: "overridenViewName",
-      backend_tracing_id: "1234567890",
+      viewName: "overridenViewName",
+      backendTracingId: "1234567890",
       meta: {
-        key_one: "value_one",
-        key_two: "value_two",
+        keyOne: "value_one",
+        keyTwo: "value_two",
       },
     });
   }

--- a/InstanaExample/android/app/build.gradle
+++ b/InstanaExample/android/app/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "com.instana:android-agent-plugin:1.1.2"
+        classpath "com.instana:android-agent-plugin:1.2.0"
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the Instana Android agent plugin to your dependencies via `android/build.gra
 ```groovy
 buildscript {
     dependencies {
-        classpath 'com.instana:android-agent-plugin:1.1.2'
+        classpath 'com.instana:android-agent-plugin:1.2.0'
     }
 }
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation "com.instana:android-agent-runtime:1.1.2"
+    implementation "com.instana:android-agent-runtime:1.2.0"
 
 }
 

--- a/android/src/main/java/com/instana/rn/InstanaEumModule.java
+++ b/android/src/main/java/com/instana/rn/InstanaEumModule.java
@@ -12,15 +12,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.Promise;
 import com.instana.android.Instana;
 import com.instana.android.CustomEvent;
 import com.instana.android.core.InstanaConfig;
+
+import javax.annotation.Nullable;
 
 public class InstanaEumModule extends ReactContextBaseJavaModule {
 
@@ -44,13 +44,13 @@ public class InstanaEumModule extends ReactContextBaseJavaModule {
 
     @Override
     public Map<String, Object> getConstants() {
-      final Map<String, Object> constants = new HashMap<>();
-      constants.put(CUSTOMEVENT_START_TIME, CUSTOMEVENT_START_TIME);
-      constants.put(CUSTOMEVENT_DURATION, CUSTOMEVENT_DURATION);
-      constants.put(CUSTOMEVENT_VIEW_NAME, CUSTOMEVENT_VIEW_NAME);
-      constants.put(CUSTOMEVENT_META, CUSTOMEVENT_META);
-      constants.put(CUSTOMEVENT_BACKEND_TRACING_ID, CUSTOMEVENT_BACKEND_TRACING_ID);
-      return constants;
+        final Map<String, Object> constants = new HashMap<>();
+        constants.put(CUSTOMEVENT_START_TIME, CUSTOMEVENT_START_TIME);
+        constants.put(CUSTOMEVENT_DURATION, CUSTOMEVENT_DURATION);
+        constants.put(CUSTOMEVENT_VIEW_NAME, CUSTOMEVENT_VIEW_NAME);
+        constants.put(CUSTOMEVENT_META, CUSTOMEVENT_META);
+        constants.put(CUSTOMEVENT_BACKEND_TRACING_ID, CUSTOMEVENT_BACKEND_TRACING_ID);
+        return constants;
     }
 
     @ReactMethod
@@ -121,7 +121,7 @@ public class InstanaEumModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void reportEvent(String eventName, ReadableMap options) {
+    public void reportEvent(String eventName, @Nullable ReadableMap options) {
         CustomEvent event = new CustomEvent(eventName);
         if (options != null) {
             if (options.hasKey(CUSTOMEVENT_START_TIME)) {
@@ -137,7 +137,7 @@ public class InstanaEumModule extends ReactContextBaseJavaModule {
                 event.setBackendTracingID(options.getString(CUSTOMEVENT_BACKEND_TRACING_ID));
             }
             if (options.hasKey(CUSTOMEVENT_META)) {
-                HashMap metaMap = new HashMap<String,String>();
+                HashMap metaMap = new HashMap<String, String>();
                 ReadableMap readableMap = options.getMap(CUSTOMEVENT_META);
                 ReadableMapKeySetIterator keySetIterator = readableMap.keySetIterator();
                 while (keySetIterator.hasNextKey()) {

--- a/android/src/main/java/com/instana/rn/InstanaEumModule.java
+++ b/android/src/main/java/com/instana/rn/InstanaEumModule.java
@@ -128,7 +128,7 @@ public class InstanaEumModule extends ReactContextBaseJavaModule {
                 event.setStartTime((long) options.getDouble(CUSTOMEVENT_START_TIME));
             }
             if (options.hasKey(CUSTOMEVENT_DURATION)) {
-                event.setDuration((long)options.getDouble(CUSTOMEVENT_DURATION));
+                event.setDuration((long) options.getDouble(CUSTOMEVENT_DURATION));
             }
             if (options.hasKey(CUSTOMEVENT_VIEW_NAME)) {
                 event.setViewName(options.getString(CUSTOMEVENT_VIEW_NAME));

--- a/android/src/main/java/com/instana/rn/InstanaEumModule.java
+++ b/android/src/main/java/com/instana/rn/InstanaEumModule.java
@@ -26,11 +26,11 @@ public class InstanaEumModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
 
-    private static final String CUSTOMEVENT_START_TIME = "start_time";
+    private static final String CUSTOMEVENT_START_TIME = "startTime";
     private static final String CUSTOMEVENT_DURATION = "duration";
-    private static final String CUSTOMEVENT_VIEW_NAME = "view_name";
+    private static final String CUSTOMEVENT_VIEW_NAME = "viewName";
     private static final String CUSTOMEVENT_META = "meta";
-    private static final String CUSTOMEVENT_BACKEND_TRACING_ID = "backend_tracing_id";
+    private static final String CUSTOMEVENT_BACKEND_TRACING_ID = "backendTracingId";
 
     public InstanaEumModule(ReactApplicationContext reactContext) {
         super(reactContext);


### PR DESCRIPTION
This PR introduces support for custom events with a API familiar to javascript developers, an Android implementation and a example.

API: 

```javascript
Instana.reportEvent("eventName" (string), options (dictionary));
```

Usage example: 
```javascript
Instana.reportEvent("myCustomEvent", {
      startTime: epochMs-500,
      duration: 300,
      viewName: "overridenViewName",
      backendTracingId: "1234567890",
      meta: {
        keyOne: "value_one",
        keyTwo: "value_two",
      },
    });
```